### PR TITLE
Documentation for the gumath package.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,14 @@
+# Makefile for Sphinx documentation.
+SPHINXBUILD = sphinx-build
+BUILDDIR = build
+
+default: html
+
+html:
+	sphinx-build -b html -d build/doctrees . build/html
+
+doctest:
+	sphinx-build -b doctest -d build/doctrees . build/html
+
+clean:
+	rm -rf $(BUILDDIR)/*

--- a/doc/_static/copybutton.js
+++ b/doc/_static/copybutton.js
@@ -1,0 +1,66 @@
+// Copyright 2014 PSF. Licensed under the PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+// File originates from the cpython source found in Doc/tools/sphinxext/static/copybutton.js
+
+$(document).ready(function() {
+    /* Add a [>>>] button on the top-right corner of code samples to hide
+     * the >>> and ... prompts and the output and thus make the code
+     * copyable. */
+    var div = $('.highlight-py .highlight,' +
+                '.highlight-default .highlight,' +
+                '.highlight-py3 .highlight')
+    var pre = div.find('pre');
+
+    // get the styles from the current theme
+    pre.parent().parent().css('position', 'relative');
+    var hide_text = 'Hide the prompts and output';
+    var show_text = 'Show the prompts and output';
+    var border_width = pre.css('border-top-width');
+    var border_style = pre.css('border-top-style');
+    var border_color = pre.css('border-top-color');
+    var button_styles = {
+        'cursor':'pointer', 'position': 'absolute', 'top': '0', 'right': '0',
+        'border-color': border_color, 'border-style': border_style,
+        'border-width': border_width, 'color': border_color, 'text-size': '75%',
+        'font-family': 'monospace', 'padding-left': '0.2em', 'padding-right': '0.2em',
+        'border-radius': '0 3px 0 0'
+    }
+
+    // create and add the button to all the code blocks that contain >>>
+    div.each(function(index) {
+        var jthis = $(this);
+        if (jthis.find('.gp').length > 0) {
+            var button = $('<span class="copybutton">&gt;&gt;&gt;</span>');
+            button.css(button_styles)
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+            jthis.prepend(button);
+        }
+        // tracebacks (.gt) contain bare text elements that need to be
+        // wrapped in a span to work with .nextUntil() (see later)
+        jthis.find('pre:has(.gt)').contents().filter(function() {
+            return ((this.nodeType == 3) && (this.data.trim().length > 0));
+        }).wrap('<span>');
+    });
+
+    // define the behavior of the button when it's clicked
+    $('.copybutton').click(function(e){
+        e.preventDefault();
+        var button = $(this);
+        if (button.data('hidden') === 'false') {
+            // hide the code output
+            button.parent().find('.go, .gp, .gt').hide();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'hidden');
+            button.css('text-decoration', 'line-through');
+            button.attr('title', show_text);
+            button.data('hidden', 'true');
+        } else {
+            // show the code output
+            button.parent().find('.go, .gp, .gt').show();
+            button.next('pre').find('.gt').nextUntil('.gp, .go').css('visibility', 'visible');
+            button.css('text-decoration', 'none');
+            button.attr('title', hide_text);
+            button.data('hidden', 'false');
+        }
+    });
+});
+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,26 @@
+import sys, os, docutils
+
+
+extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.doctest']
+
+source_suffix = '.rst'
+master_doc = 'index'
+project = 'gumath'
+copyright = '2017-2018, Plures Project'
+version = 'v0.2.0dev3'
+release = 'v0.2.0dev3'
+exclude_patterns = ['doc', 'build']
+pygments_style = 'sphinx'
+html_static_path = ['_static']
+
+primary_domain = 'py'
+add_function_parentheses = False
+
+
+def setup(app):
+    app.add_crossref_type('topic', 'topic', 'single: %s',
+                          docutils.nodes.strong)
+    app.add_javascript("copybutton.js")
+
+
+

--- a/doc/gumath/index.rst
+++ b/doc/gumath/index.rst
@@ -1,0 +1,20 @@
+.. meta::
+   :robots: index, follow
+   :description: gumath documentation
+   :keywords: gumath, mathematical functions, Python
+
+.. sectionauthor:: Vital Fernandez <vital-fernandez at gmail.com>
+
+
+Mathematical operations
+=======================
+
+The gumath functions provide a python wrapper for the libgumath library. The mathematical operation currently provided is sine.
+
+Trigonometry functions
+----------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   trigonometry/index.rst

--- a/doc/gumath/index.rst
+++ b/doc/gumath/index.rst
@@ -1,7 +1,7 @@
 .. meta::
    :robots: index, follow
    :description: gumath documentation
-   :keywords: gumath, mathematical functions, Python
+   :keywords: gumath, mathematical operations, Python
 
 .. sectionauthor:: Vital Fernandez <vital-fernandez at gmail.com>
 
@@ -9,7 +9,8 @@
 Mathematical operations
 =======================
 
-The gumath functions provide a python wrapper for the libgumath library. The mathematical operation currently provided is sine.
+The gumath functions provide a python wrapper for the libgumath library. The sine operation is currently the
+only one available.
 
 Trigonometry functions
 ----------------------

--- a/doc/gumath/trigonometry/index.rst
+++ b/doc/gumath/trigonometry/index.rst
@@ -1,7 +1,7 @@
 .. meta::
    :robots: index, follow
    :description: gumath documentation
-   :keywords: gumath, sin, Python
+   :keywords: gumath, trigonometry, sin, Python
 
 .. sectionauthor:: Vital Fernandez <vital-fernandez at gmail.com>
 
@@ -39,5 +39,3 @@ Example
    >>> gm.sin(xnd(x))
    xnd([0.0, 0.49999, 0.99999], type='3 * float64')
 
-Notes
-=====

--- a/doc/gumath/trigonometry/index.rst
+++ b/doc/gumath/trigonometry/index.rst
@@ -1,0 +1,43 @@
+.. meta::
+   :robots: index, follow
+   :description: gumath documentation
+   :keywords: gumath, sin, Python
+
+.. sectionauthor:: Vital Fernandez <vital-fernandez at gmail.com>
+
+
+sin
+===
+
+Trigonometric sine, element-wise.
+
+Parameters
+----------
+
+Atributes
+^^^^^^^^^
+
+x: array_like
+Angle, in radians (2*pi rad equals 360 degrees).
+
+Returns
+^^^^^^^
+
+y: array_like
+The sine of each element of x.
+
+returns: array:like
+
+Example
+-------
+
+.. doctest::
+
+   >>> import gumath as gm
+   >>> from xnd import xnd
+   >>> x = [0.0, 30 * 3.14159/180, 90 * 3.14159/180]
+   >>> gm.sin(xnd(x))
+   xnd([0.0, 0.49999, 0.99999], type='3 * float64')
+
+Notes
+=====

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,7 +1,7 @@
 .. meta::
    :robots: index, follow
    :description: gumath documentation
-   :keywords: libgumath, gumath, C, Python, array computing
+   :keywords: libgumath, gumath, C, Python, function dispatch
 
 .. sectionauthor:: Stefan Krah <skrah at bytereef.org>
 
@@ -9,7 +9,8 @@
 gumath
 ======
 
-gumath is a Python wrapper for the ligmumath library. It provides support for the function dispatch.
+This package provides tools to dispatch functions towards the memory containers. These containers can be have a general
+ sctructure or a Numpy-like container with a composable, generalized function concept.
 
 
 Libgumath

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,44 @@
+.. meta::
+   :robots: index, follow
+   :description: gumath documentation
+   :keywords: libgumath, gumath, C, Python, array computing
+
+.. sectionauthor:: Stefan Krah <skrah at bytereef.org>
+
+
+gumath
+======
+
+gumath is a Python wrapper for the ligmumath library. It provides support for the function dispatch.
+
+
+Libgumath
+---------
+
+C library.
+
+.. toctree::
+   :maxdepth: 1
+
+   libgumath/index.rst
+
+
+Gumath
+------
+
+Python module.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   gumath/index.rst
+
+
+Releases
+--------
+
+.. toctree::
+   :maxdepth: 1
+
+   releases/index.rst

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,7 +10,7 @@ gumath
 ======
 
 This package provides tools to dispatch functions towards the memory containers. These containers can be have a general
- sctructure or a Numpy-like container with a composable, generalized function concept.
+structure or a Numpy-like container with a composable, generalized function concept.
 
 
 Libgumath

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,13 +5,37 @@
 
 .. sectionauthor:: Stefan Krah <skrah at bytereef.org>
 
-
+******
 gumath
-======
+******
 
 This package provides tools to dispatch functions towards the memory containers. These containers can be have a general
 structure or a Numpy-like container with a composable, generalized function concept.
 
+Installation
+============
+
+To run gumathn `xnd`_ and `ndtypes`_, your computer requires a Python interpreters, either version 2.7 or 3.6
+(the lattest stable version).
+
+gumath can be installed using `pip`_::
+
+  python3 -m pip install gumath
+
+Or using anaconda package manager `anaconda`_::
+
+  conda install -c xnd/label/dev gumath
+
+gumath does not depend on third-party Python except for `xnd`_ and `ndtypes`_ (currently, these packages do not have any
+external dependensives themselves).
+
+.. _xnd: https://github.com/plures/xnd
+.. _ndtypes: https://github.com/plures/ndtypes
+.. _pip: https://pip.pypa.io/en/latest/installing
+
+
+Index
+=====
 
 Libgumath
 ---------
@@ -29,12 +53,10 @@ Gumath
 
 Python module.
 
-
 .. toctree::
    :maxdepth: 1
 
    gumath/index.rst
-
 
 Releases
 --------

--- a/doc/libgumath/gufunc.rst
+++ b/doc/libgumath/gufunc.rst
@@ -1,0 +1,15 @@
+Gufunc
+======
+
+A gufunc is defined as a name and a collection of associated kernels.  Gufunc
+structs are in a lookup table with their names as keys:
+
+.. code-block:: c
+
+   typedef struct {
+       char *name;
+       int nkernels;
+       gm_kernel_t kernels[GM_MAX_KERNELS];
+   } gm_func_t;
+
+Since each kernel has its own type signature, gufuncs are essentially multimethods.

--- a/doc/libgumath/gufunc.rst
+++ b/doc/libgumath/gufunc.rst
@@ -1,3 +1,10 @@
+.. meta::
+   :robots: index, follow
+   :description: gumath documentation
+   :keywords: function dispatch, mathematical functions, C, multimethods
+
+.. sectionauthor:: Stefan Krah <skrah at bytereef.org>
+
 Gufunc
 ======
 

--- a/doc/libgumath/index.rst
+++ b/doc/libgumath/index.rst
@@ -1,7 +1,7 @@
 .. meta::
    :robots: index, follow
    :description: libgumath documentation
-   :keywords: libgumath, C, array computing
+   :keywords: libgumath, C
 
 .. sectionauthor:: Stefan Krah <skrah at bytereef.org>
 

--- a/doc/libgumath/index.rst
+++ b/doc/libgumath/index.rst
@@ -1,0 +1,26 @@
+.. meta::
+   :robots: index, follow
+   :description: libgumath documentation
+   :keywords: libgumath, C, array computing
+
+.. sectionauthor:: Stefan Krah <skrah at bytereef.org>
+
+
+libgumath
+---------
+
+The libgumath library implements support for the function dispatch to the memory blocks defined using the xnd library.
+
+This initial libgumath version displays a simple design. The goal is
+to determine whether the kernel signatures and the dispatch model are suitable
+for Numba.
+
+Currently there is just one working test with sin().
+
+.. toctree::
+
+   gufunc.rst
+   kernel.rst
+   numba_integration.rst
+
+

--- a/doc/libgumath/kernel.rst
+++ b/doc/libgumath/kernel.rst
@@ -1,0 +1,73 @@
+Kernel
+======
+
+The kernel struct contains the type signature together with several (possibly
+optimized) kernel functions.  Each of these functions may be NULL.
+
+.. code-block:: c
+
+   typedef void (* gm_c_kernel_t)(xnd_ndarray_t stack[]);
+   typedef void (* gm_fortran_kernel_t)(xnd_ndarray_t stack[]);
+   typedef void (* gm_strided_kernel_t)(xnd_ndarray_t stack[]);
+   typedef void (* gm_xnd_kernel_t)(xnd_t stack[]);
+
+   typedef struct {
+       ndt_t *sig;
+
+       gm_c_kernel_t C;
+       gm_fortran_kernel_t Fortran;
+       gm_strided_kernel_t Strided;
+       gm_xnd_kernel_t Xnd;
+   } gm_kernel_t;
+
+
+The idea is to have highly optimized kernels for contiguous C and Fortran
+arrays, a generic strided kernel for non-contiguous arrays and Xnd kernels
+for situations where variable arrays or optional values are needed.
+
+For Numpy arrays the Xnd struct member may be NULL.
+
+
+Kernel application
+------------------
+
+The algorithm for gufunc application can be seen in the Python module.
+
+1. Get the function name and the list of xnd function arguments.
+
+2. Get the types of the function arguments.
+
+3. Select the kernel:
+
+   a. Lookup the gufunc in the function table.
+
+   b. Iterate over the type signatures.
+
+      i.  If no match is found, return an error.
+
+      ii. If a match is found, compute the return type(s) and the number
+          of outer dimensions to be skipped.
+
+          This stage should probably also do broadcasting, which is currently not implemented.
+
+4. Allocate new xnd container(s) for the return values.
+
+5. Input and output containers are pushed on a single stack. The types,
+   which are available at any stage of the array traversal, keep track
+   of the number of in/out args.
+
+6. Call gm_map(), which orchestrates kernel application.
+
+7. The actual kernel {C, Fortran, Strided, Xnd} is selected right before
+   application (in this order of preference).
+
+   If no kernel is found, an error is returned.
+
+
+More specialized kernel signatures
+----------------------------------
+
+What to add to {C, Fortran, Strided, Xnd}?
+
+MKL would be an obvious choice.  Another idea is to support kernels with
+closure-like state and constr/destructor functions for the state.

--- a/doc/libgumath/kernel.rst
+++ b/doc/libgumath/kernel.rst
@@ -1,3 +1,10 @@
+.. meta::
+   :robots: index, follow
+   :description: libgumath documentation
+   :keywords: libgumath, function dispatch, kernel, C
+
+.. sectionauthor:: Stefan Krah <skrah at bytereef.org>
+
 Kernel
 ======
 

--- a/doc/libgumath/numba_integration.rst
+++ b/doc/libgumath/numba_integration.rst
@@ -1,3 +1,10 @@
+.. meta::
+   :robots: index, follow
+   :description: libgumath documentation
+   :keywords: libgumath, function dispatch, numba, C
+
+.. sectionauthor:: Stefan Krah <skrah at bytereef.org>
+
 Numba integration
 =================
 

--- a/doc/libgumath/numba_integration.rst
+++ b/doc/libgumath/numba_integration.rst
@@ -1,0 +1,19 @@
+Numba integration
+=================
+
+The basic idea is that libgumath contains functions that allow inserting
+gufuncs and kernels into the lookup table.
+
+Ideally, Numba would jit-compile specialized kernels and call the insertion
+function (must be on the C level for safety).
+
+The function is then automatically available to be called on the Python
+level via the gumath Python module.
+
+
+Obstacles
+---------
+
+- If the datashape (ndt_t) signatures are given on the Python level (which
+  is probably the only sane option), the jit-compiled kernel needs to be
+  type-checked against the ndt_t type.

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -20,9 +20,4 @@ for Numba.
 
 Currently there is just one working test with sin().
 
-The following list includes some of the issues to be discussed before the next release:
-
--  If the datashape (ndt_t) signatures are given on the Python level (which is probably the only sane option),
-the jit-compiled kernel needs to be type-checked against the ndt_t type.
-
 

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -1,0 +1,29 @@
+.. meta::
+   :robots: index, follow
+   :description: libgumath documentation
+   :keywords: libgumath, C, array computing
+
+.. sectionauthor:: Stefan Krah <skrah at bytereef.org>
+
+
+========
+Releases
+========
+
+
+v0.2.0b1 (January 20th 2018)
+============================
+
+The first version of libgumath has a relatively simple design.  The goal is
+to determine whether the kernel signatures and the dispatch model are suitable
+for Numba.
+
+Currently there is just one working test with sin().
+
+The following list includes some of the issues to be discussed before the next release:
+
+-  If the datashape (ndt_t) signatures are given on the Python level (which
+  is probably the only sane option), the jit-compiled kernel needs to be
+  type-checked against the ndt_t type.
+
+

--- a/doc/releases/index.rst
+++ b/doc/releases/index.rst
@@ -1,7 +1,7 @@
 .. meta::
    :robots: index, follow
    :description: libgumath documentation
-   :keywords: libgumath, C, array computing
+   :keywords: gumath, libgumath, C, releases
 
 .. sectionauthor:: Stefan Krah <skrah at bytereef.org>
 
@@ -11,7 +11,7 @@ Releases
 ========
 
 
-v0.2.0b1 (January 20th 2018)
+v0.2.0b2 (February 5th 2018)
 ============================
 
 The first version of libgumath has a relatively simple design.  The goal is
@@ -22,8 +22,7 @@ Currently there is just one working test with sin().
 
 The following list includes some of the issues to be discussed before the next release:
 
--  If the datashape (ndt_t) signatures are given on the Python level (which
-  is probably the only sane option), the jit-compiled kernel needs to be
-  type-checked against the ndt_t type.
+-  If the datashape (ndt_t) signatures are given on the Python level (which is probably the only sane option),
+the jit-compiled kernel needs to be type-checked against the ndt_t type.
 
 


### PR DESCRIPTION
The contents from the experimental doc/experimental/dispatch.rst have been styled to imitate the xnd and dtypes documentation (this subfolder and file could be deleted now). There is also a new entry for the sin function which includes an example.