### PR TITLE
Fix duplicate symbols error

### DIFF
--- a/ruby/ext/ruby_gumath/gufunc_object.c
+++ b/ruby/ext/ruby_gumath/gufunc_object.c
@@ -35,6 +35,8 @@
 /*                               Gufunc Object                              */
 /****************************************************************************/
 
+VALUE cGumath_GufuncObject;
+
 static void
 GufuncObject_dfree(void *self)
 {

--- a/ruby/ext/ruby_gumath/gufunc_object.h
+++ b/ruby/ext/ruby_gumath/gufunc_object.h
@@ -38,8 +38,8 @@ typedef struct {
   char *name;                     /* function name */
 } GufuncObject;
 
-const rb_data_type_t GufuncObject_type;
-VALUE cGumath_GufuncObject;
+extern const rb_data_type_t GufuncObject_type;
+extern VALUE cGumath_GufuncObject;
 
 #define GET_GUOBJ(obj, guobj_p) do {                              \
     TypedData_Get_Struct((obj), GufuncObject,                     \

--- a/ruby/ext/ruby_gumath/ruby_gumath.c
+++ b/ruby/ext/ruby_gumath/ruby_gumath.c
@@ -43,7 +43,7 @@ static gm_tbl_t *table = NULL;
 /* Maximum number of threads */
 static int64_t max_threads = 1;
 static int initialized = 0;
-extern VALUE cGumath;
+VALUE cGumath;
 
 /****************************************************************************/
 /*                               Error handling                             */

--- a/ruby/ext/ruby_gumath/ruby_gumath.h
+++ b/ruby/ext/ruby_gumath/ruby_gumath.h
@@ -33,7 +33,7 @@
 #define RUBY_GUMATH_H
 
 /* Classes */
-VALUE cGumath;
+extern VALUE cGumath;
 
 int rb_gumath_add_functions(VALUE module, const gm_tbl_t *tbl);
 #define GUMATH_FUNCTION_HASH rb_intern("@gumath_functions")


### PR DESCRIPTION
This commit fixes the following errors:

```
linking shared-object ruby_gumath/ruby_gumath.bundle
duplicate symbol _cGumath_GufuncObject in:
    util.o
    gufunc_object.o
duplicate symbol _cGumath in:
    util.o
    gufunc_object.o
duplicate symbol _GufuncObject_type in:
    util.o
    gufunc_object.o
duplicate symbol _cGumath_GufuncObject in:
    util.o
    functions.o
duplicate symbol _cGumath in:
    util.o
    functions.o
duplicate symbol _GufuncObject_type in:
    util.o
    functions.o
duplicate symbol _cGumath_GufuncObject in:
    util.o
    ruby_gumath.o
duplicate symbol _cGumath in:
    util.o
    ruby_gumath.o
duplicate symbol _GufuncObject_type in:
    util.o
    ruby_gumath.o
duplicate symbol _cGumath_GufuncObject in:
    util.o
    examples.o
duplicate symbol _cGumath in:
    util.o
    examples.o
duplicate symbol _GufuncObject_type in:
    util.o
    examples.o
ld: 12 duplicate symbols for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)```
```