### PR TITLE
Add equaln gufunc.

### DIFF
--- a/libgumath/kernels/cpu_device_binary.cc
+++ b/libgumath/kernels/cpu_device_binary.cc
@@ -972,6 +972,9 @@ CPU_DEVICE_ALL_COMPARISON(equal, equal, equal, equal)
 #define not_equal(x, y) x != y
 CPU_DEVICE_ALL_COMPARISON(not_equal, not_equal, not_equal, not_equal)
 
+#define equivalent(x, y) (x == y || (x != x && y != y))
+CPU_DEVICE_ALL_COMPARISON(equivalent, equivalent, equivalent, lexorder_equiv)
+
 
 /*****************************************************************************/
 /*                                  Bitwise                                  */

--- a/libgumath/kernels/cpu_device_binary.cc
+++ b/libgumath/kernels/cpu_device_binary.cc
@@ -972,8 +972,8 @@ CPU_DEVICE_ALL_COMPARISON(equal, equal, equal, equal)
 #define not_equal(x, y) x != y
 CPU_DEVICE_ALL_COMPARISON(not_equal, not_equal, not_equal, not_equal)
 
-#define equivalent(x, y) (x == y || (x != x && y != y))
-CPU_DEVICE_ALL_COMPARISON(equivalent, equivalent, equivalent, lexorder_equiv)
+#define equaln(x, y) (x == y || (x != x && y != y))
+CPU_DEVICE_ALL_COMPARISON(equaln, equaln, equaln, lexorder_eqn)
 
 
 /*****************************************************************************/

--- a/libgumath/kernels/cpu_device_binary.h
+++ b/libgumath/kernels/cpu_device_binary.h
@@ -943,7 +943,7 @@ CPU_DEVICE_ALL_COMPARISON_DECL(greater_equal)
 CPU_DEVICE_ALL_COMPARISON_DECL(greater)
 CPU_DEVICE_ALL_COMPARISON_DECL(equal)
 CPU_DEVICE_ALL_COMPARISON_DECL(not_equal)
-CPU_DEVICE_ALL_COMPARISON_DECL(equivalent)
+CPU_DEVICE_ALL_COMPARISON_DECL(equaln)
 
 
 /*****************************************************************************/

--- a/libgumath/kernels/cpu_device_binary.h
+++ b/libgumath/kernels/cpu_device_binary.h
@@ -943,6 +943,7 @@ CPU_DEVICE_ALL_COMPARISON_DECL(greater_equal)
 CPU_DEVICE_ALL_COMPARISON_DECL(greater)
 CPU_DEVICE_ALL_COMPARISON_DECL(equal)
 CPU_DEVICE_ALL_COMPARISON_DECL(not_equal)
+CPU_DEVICE_ALL_COMPARISON_DECL(equivalent)
 
 
 /*****************************************************************************/

--- a/libgumath/kernels/cpu_device_msvc.cc
+++ b/libgumath/kernels/cpu_device_msvc.cc
@@ -271,7 +271,7 @@ lexorder_gt(T a, U b)
 }
 
 template <class T, class U>
-static inline DEVICE bool
+static inline bool
 lexorder_equiv(T a, U b)
 {
     bool real_equal = a.real() == b.real() || (ISNAN(a.real()) && ISNAN(b.real()));

--- a/libgumath/kernels/cpu_device_msvc.cc
+++ b/libgumath/kernels/cpu_device_msvc.cc
@@ -270,6 +270,16 @@ lexorder_gt(T a, U b)
     return a.real() > b.real() || (a.real() == b.real() && a.imag() > b.imag());
 }
 
+template <class T, class U>
+static inline DEVICE bool
+lexorder_equiv(T a, U b)
+{
+    bool real_equal = a.real() == b.real() || (ISNAN(a.real()) && ISNAN(b.real()));
+    bool imag_equal = a.imag() == b.imag() || (ISNAN(a.imag()) && ISNAN(b.imag()));
+
+    return real_equal && imag_equal;
+}
+
 
 /*****************************************************************************/
 /*                         CPU device binary kernels                         */
@@ -601,3 +611,6 @@ CPU_DEVICE_ALL_COMPARISON(equal, equal, equal, equal)
 
 #define not_equal(x, y) x != y
 CPU_DEVICE_ALL_COMPARISON(not_equal, not_equal, not_equal, not_equal)
+
+#define equivalent(x, y) (x == y || (x != x && y != y))
+CPU_DEVICE_ALL_COMPARISON(equivalent, equivalent, equivalent, lexorder_equiv)

--- a/libgumath/kernels/cpu_device_msvc.cc
+++ b/libgumath/kernels/cpu_device_msvc.cc
@@ -274,8 +274,8 @@ template <class T, class U>
 static inline bool
 lexorder_equiv(T a, U b)
 {
-    bool real_equal = a.real() == b.real() || (ISNAN(a.real()) && ISNAN(b.real()));
-    bool imag_equal = a.imag() == b.imag() || (ISNAN(a.imag()) && ISNAN(b.imag()));
+    bool real_equal = a.real() == b.real() || (std::isnan(a.real()) && std::isnan(b.real()));
+    bool imag_equal = a.imag() == b.imag() || (std::isnan(a.imag()) && std::isnan(b.imag()));
 
     return real_equal && imag_equal;
 }

--- a/libgumath/kernels/cpu_device_msvc.cc
+++ b/libgumath/kernels/cpu_device_msvc.cc
@@ -272,7 +272,7 @@ lexorder_gt(T a, U b)
 
 template <class T, class U>
 static inline bool
-lexorder_equiv(T a, U b)
+lexorder_eqn(T a, U b)
 {
     bool real_equal = a.real() == b.real() || (std::isnan(a.real()) && std::isnan(b.real()));
     bool imag_equal = a.imag() == b.imag() || (std::isnan(a.imag()) && std::isnan(b.imag()));
@@ -612,5 +612,5 @@ CPU_DEVICE_ALL_COMPARISON(equal, equal, equal, equal)
 #define not_equal(x, y) x != y
 CPU_DEVICE_ALL_COMPARISON(not_equal, not_equal, not_equal, not_equal)
 
-#define equivalent(x, y) (x == y || (x != x && y != y))
-CPU_DEVICE_ALL_COMPARISON(equivalent, equivalent, equivalent, lexorder_equiv)
+#define equaln(x, y) (x == y || (x != x && y != y))
+CPU_DEVICE_ALL_COMPARISON(equaln, equaln, equaln, lexorder_eqn)

--- a/libgumath/kernels/cpu_host_binary.c
+++ b/libgumath/kernels/cpu_host_binary.c
@@ -2201,6 +2201,7 @@ CPU_HOST_ALL_COMPARISON(greater_equal)
 CPU_HOST_ALL_COMPARISON(greater)
 CPU_HOST_ALL_COMPARISON(equal)
 CPU_HOST_ALL_COMPARISON(not_equal)
+CPU_HOST_ALL_COMPARISON(equivalent)
 
 
 static const gm_kernel_init_t binary_kernels[] = {
@@ -2216,6 +2217,7 @@ static const gm_kernel_init_t binary_kernels[] = {
   CPU_HOST_ALL_COMPARISON_INIT(greater),
   CPU_HOST_ALL_COMPARISON_INIT(equal),
   CPU_HOST_ALL_COMPARISON_INIT(not_equal),
+  CPU_HOST_ALL_COMPARISON_INIT(equivalent),
 
   { .name = NULL, .sig = NULL }
 };

--- a/libgumath/kernels/cpu_host_binary.c
+++ b/libgumath/kernels/cpu_host_binary.c
@@ -2201,7 +2201,7 @@ CPU_HOST_ALL_COMPARISON(greater_equal)
 CPU_HOST_ALL_COMPARISON(greater)
 CPU_HOST_ALL_COMPARISON(equal)
 CPU_HOST_ALL_COMPARISON(not_equal)
-CPU_HOST_ALL_COMPARISON(equivalent)
+CPU_HOST_ALL_COMPARISON(equaln)
 
 
 static const gm_kernel_init_t binary_kernels[] = {
@@ -2217,7 +2217,7 @@ static const gm_kernel_init_t binary_kernels[] = {
   CPU_HOST_ALL_COMPARISON_INIT(greater),
   CPU_HOST_ALL_COMPARISON_INIT(equal),
   CPU_HOST_ALL_COMPARISON_INIT(not_equal),
-  CPU_HOST_ALL_COMPARISON_INIT(equivalent),
+  CPU_HOST_ALL_COMPARISON_INIT(equaln),
 
   { .name = NULL, .sig = NULL }
 };

--- a/libgumath/kernels/cuda_device_binary.cu
+++ b/libgumath/kernels/cuda_device_binary.cu
@@ -991,7 +991,7 @@ CUDA_DEVICE_ALL_COMPARISON(equal, equal, __heq, equal)
 CUDA_DEVICE_ALL_COMPARISON(not_equal, not_equal, half_ne, not_equal)
 
 #define equivalent(x, y) (x == y || (x != x && y != y))
-CUDA_DEVICE_ALL_COMPARISON(equivalent, equivalent, __heq, lexorder_equiv)
+CUDA_DEVICE_ALL_COMPARISON(equivalent, equivalent, half_equiv, lexorder_equiv)
 
 
 /*****************************************************************************/

--- a/libgumath/kernels/cuda_device_binary.cu
+++ b/libgumath/kernels/cuda_device_binary.cu
@@ -990,8 +990,8 @@ CUDA_DEVICE_ALL_COMPARISON(equal, equal, __heq, equal)
 #define not_equal(x, y) x != y
 CUDA_DEVICE_ALL_COMPARISON(not_equal, not_equal, half_ne, not_equal)
 
-#define equivalent(x, y) (x == y || (x != x && y != y))
-CUDA_DEVICE_ALL_COMPARISON(equivalent, equivalent, half_equiv, lexorder_equiv)
+#define equaln(x, y) (x == y || (x != x && y != y))
+CUDA_DEVICE_ALL_COMPARISON(equaln, equaln, half_eqn, lexorder_eqn)
 
 
 /*****************************************************************************/

--- a/libgumath/kernels/cuda_device_binary.cu
+++ b/libgumath/kernels/cuda_device_binary.cu
@@ -990,6 +990,9 @@ CUDA_DEVICE_ALL_COMPARISON(equal, equal, __heq, equal)
 #define not_equal(x, y) x != y
 CUDA_DEVICE_ALL_COMPARISON(not_equal, not_equal, half_ne, not_equal)
 
+#define equivalent(x, y) (x == y || (x != x && y != y))
+CUDA_DEVICE_ALL_COMPARISON(equivalent, equivalent, __heq, lexorder_equiv)
+
 
 /*****************************************************************************/
 /*                                  Bitwise                                  */

--- a/libgumath/kernels/cuda_device_binary.h
+++ b/libgumath/kernels/cuda_device_binary.h
@@ -942,6 +942,7 @@ CUDA_DEVICE_ALL_COMPARISON_DECL(greater_equal)
 CUDA_DEVICE_ALL_COMPARISON_DECL(greater)
 CUDA_DEVICE_ALL_COMPARISON_DECL(equal)
 CUDA_DEVICE_ALL_COMPARISON_DECL(not_equal)
+CUDA_DEVICE_ALL_COMPARISON_DECL(equivalent)
 
 
 /*****************************************************************************/

--- a/libgumath/kernels/cuda_device_binary.h
+++ b/libgumath/kernels/cuda_device_binary.h
@@ -942,7 +942,7 @@ CUDA_DEVICE_ALL_COMPARISON_DECL(greater_equal)
 CUDA_DEVICE_ALL_COMPARISON_DECL(greater)
 CUDA_DEVICE_ALL_COMPARISON_DECL(equal)
 CUDA_DEVICE_ALL_COMPARISON_DECL(not_equal)
-CUDA_DEVICE_ALL_COMPARISON_DECL(equivalent)
+CUDA_DEVICE_ALL_COMPARISON_DECL(equaln)
 
 
 /*****************************************************************************/

--- a/libgumath/kernels/cuda_host_binary.c
+++ b/libgumath/kernels/cuda_host_binary.c
@@ -2180,6 +2180,7 @@ CUDA_HOST_ALL_COMPARISON(greater_equal)
 CUDA_HOST_ALL_COMPARISON(greater)
 CUDA_HOST_ALL_COMPARISON(equal)
 CUDA_HOST_ALL_COMPARISON(not_equal)
+CUDA_HOST_ALL_COMPARISON(equivalent)
 
 
 static const gm_kernel_init_t binary_kernels[] = {
@@ -2195,6 +2196,7 @@ static const gm_kernel_init_t binary_kernels[] = {
   CUDA_HOST_ALL_COMPARISON_INIT(greater),
   CUDA_HOST_ALL_COMPARISON_INIT(equal),
   CUDA_HOST_ALL_COMPARISON_INIT(not_equal),
+  CUDA_HOST_ALL_COMPARISON_INIT(equivalent),
 
   { .name = NULL, .sig = NULL }
 };

--- a/libgumath/kernels/cuda_host_binary.c
+++ b/libgumath/kernels/cuda_host_binary.c
@@ -2180,7 +2180,7 @@ CUDA_HOST_ALL_COMPARISON(greater_equal)
 CUDA_HOST_ALL_COMPARISON(greater)
 CUDA_HOST_ALL_COMPARISON(equal)
 CUDA_HOST_ALL_COMPARISON(not_equal)
-CUDA_HOST_ALL_COMPARISON(equivalent)
+CUDA_HOST_ALL_COMPARISON(equaln)
 
 
 static const gm_kernel_init_t binary_kernels[] = {
@@ -2196,7 +2196,7 @@ static const gm_kernel_init_t binary_kernels[] = {
   CUDA_HOST_ALL_COMPARISON_INIT(greater),
   CUDA_HOST_ALL_COMPARISON_INIT(equal),
   CUDA_HOST_ALL_COMPARISON_INIT(not_equal),
-  CUDA_HOST_ALL_COMPARISON_INIT(equivalent),
+  CUDA_HOST_ALL_COMPARISON_INIT(equaln),
 
   { .name = NULL, .sig = NULL }
 };

--- a/libgumath/kernels/device.hh
+++ b/libgumath/kernels/device.hh
@@ -272,7 +272,7 @@ lexorder_gt(T a, U b)
 
 template <class T, class U>
 static inline DEVICE bool
-lexorder_equiv(T a, U b)
+lexorder_eqn(T a, U b)
 {
     bool real_equal = a.real() == b.real() || (ISNAN(a.real()) && ISNAN(b.real()));
     bool imag_equal = a.imag() == b.imag() || (ISNAN(a.imag()) && ISNAN(b.imag()));
@@ -293,7 +293,7 @@ half_ne(half a, half b)
 }
 
 static inline DEVICE bool
-half_equiv(half a, half b)
+half_eqn(half a, half b)
 {
     __heq(a, b) || (__hisnan(a) && __hisnan(b));
 }

--- a/libgumath/kernels/device.hh
+++ b/libgumath/kernels/device.hh
@@ -270,6 +270,16 @@ lexorder_gt(T a, U b)
     return a.real() > b.real() || (a.real() == b.real() && a.imag() > b.imag());
 }
 
+template <class T, class U>
+static inline DEVICE bool
+lexorder_equiv(T a, U b)
+{
+    bool real_equal = a.real() == b.real() || (ISNAN(a.real()) && ISNAN(b.real()));
+    bool imag_equal = a.imag() == b.imag() || (ISNAN(a.imag()) && ISNAN(b.imag()));
+
+    return real_equal && imag_equal;
+}
+
 
 /*****************************************************************************/
 /*                                Half equality                              */

--- a/libgumath/kernels/device.hh
+++ b/libgumath/kernels/device.hh
@@ -291,6 +291,12 @@ half_ne(half a, half b)
 {
     return !__heq(a, b);
 }
+
+static inline DEVICE bool
+half_equiv(half a, half b)
+{
+    __heq(a, b) || (__hisnan(a) && __hisnan(b));
+}
 #endif
 
 


### PR DESCRIPTION
Adds the `equivalent` gufunc as discussed in the call and PR #33.

```python
>>> nan_double = xnd(float('nan'))
>>> fn.equivalent(nan_double, nan_double)
xnd(True, type='bool')
>>> nan_c1 = xnd(complex(1.0, float('nan')))
>>> nan_c2 = xnd(complex(float('nan'), float('nan')))
>>> fn.equivalent(nan_c1, nan_c2)
xnd(False, type='bool')
>>> fn.equivalent(nan_c1, nan_c1)
xnd(True, type='bool')
```