### PR TITLE
numpy 1.25 compatibility

### DIFF
--- a/python/test_gumath.py
+++ b/python/test_gumath.py
@@ -51,7 +51,9 @@ except ImportError:
 
 try:
     import numpy as np
-    np.warnings.filterwarnings('ignore')
+
+    import warnings
+    warnings.filterwarnings('ignore')
 except ImportError:
     np = None
 

--- a/python/test_xndarray.py
+++ b/python/test_xndarray.py
@@ -43,7 +43,9 @@ from random import randrange
 try:
     import numpy as np
     HAVE_ARRAY_FUNCTION = hasattr(np.ndarray, '__array_function__')
-    np.warnings.filterwarnings('ignore')
+
+    import warnings
+    warnings.filterwarnings('ignore')
 except ImportError:
     np = None
     HAVE_ARRAY_FUNCTION = False

--- a/python/test_xndarray.py
+++ b/python/test_xndarray.py
@@ -372,7 +372,6 @@ class TestArrayFunc(unittest.TestCase):
         expected = np.bartlett(np.array(12, dtype="int32"))
         x = array(12, dtype="int32")
         ans = np.bartlett(x)
-        self.assertIsInstance(ans, array)
         np.testing.assert_equal(ans, expected)
 
     def test_binary(self):


### PR DESCRIPTION
1. It seems that `np.warnings` was an alias for `warnings` from the standard library, and it was removed.
2. https://github.com/numpy/numpy/pull/23705 had the side effect that `np.bartlett` no longer preserves the array type that is passed into it. However, it doesn't look like `np.bartlett` was expected to do that, so I removed that assertion.